### PR TITLE
Exclude v0.* URLs from search engine indexes

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -7,6 +7,13 @@ Disallow: /en/v0.5.2/
 Disallow: /en/v0.6.0/
 Disallow: /en/v0.6.1/
 Disallow: /en/v0.6.2/
+Disallow: /en/v0.7.0/
+# We also have v#.# URLs. They are implemented with symlinks on gh-pages, but they
+# do not behave like redirects, so we need to exclude them too.
+Disallow: /en/v0.4/
+Disallow: /en/v0.5/
+Disallow: /en/v0.6/
+Disallow: /en/v0.7/
 # Also exclude the old release-0.x directories. While they have since been
 # removed, they still show up on searches sometimes. Hopefully this will
 # cause them to be de-indexed.

--- a/robots.txt
+++ b/robots.txt
@@ -10,6 +10,7 @@ Disallow: /en/v0.6.2/
 Disallow: /en/v0.7.0/
 # We also have v#.# URLs. They are implemented with symlinks on gh-pages, but they
 # do not behave like redirects, so we need to exclude them too.
+Disallow: /en/v0.3/
 Disallow: /en/v0.4/
 Disallow: /en/v0.5/
 Disallow: /en/v0.6/


### PR DESCRIPTION
And `v0.7.0/` too, as it has a canonical URL pointing to `stable/`, which does not exist anymore.
