### PR TITLE
Retroactive fix: Boost title match ranking in search results

### DIFF
--- a/en/1.3.0-rc1.0/assets/search.js
+++ b/en/1.3.0-rc1.0/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title')
+        this.field('title', {boost: 10})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/1.3.0-rc1.0/assets/search.js
+++ b/en/1.3.0-rc1.0/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title', {boost: 10})
+        this.field('title', {boost: 100})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v0.6.0/assets/search.js
+++ b/en/v0.6.0/assets/search.js
@@ -48,7 +48,7 @@ var currentScript = document.currentScript;
 require(["jquery", "lunr"], function($, lunr) {
     var index = lunr(function () {
         this.ref('location')
-        this.field('title', {boost: 10})
+        this.field('title', {boost: 100})
         this.field('text')
     })
     var store = {}

--- a/en/v0.6.1/assets/search.js
+++ b/en/v0.6.1/assets/search.js
@@ -48,7 +48,7 @@ var currentScript = document.currentScript;
 require(["jquery", "lunr"], function($, lunr) {
     var index = lunr(function () {
         this.ref('location')
-        this.field('title', {boost: 10})
+        this.field('title', {boost: 100})
         this.field('text')
     })
     var store = {}

--- a/en/v0.6.2/assets/search.js
+++ b/en/v0.6.2/assets/search.js
@@ -48,7 +48,7 @@ var currentScript = document.currentScript;
 require(["jquery", "lunr"], function($, lunr) {
     var index = lunr(function () {
         this.ref('location')
-        this.field('title', {boost: 10})
+        this.field('title', {boost: 100})
         this.field('text')
     })
     var store = {}

--- a/en/v0.6.3/assets/search.js
+++ b/en/v0.6.3/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title')
+        this.field('title', {boost: 10})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v0.6.3/assets/search.js
+++ b/en/v0.6.3/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title', {boost: 10})
+        this.field('title', {boost: 100})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v0.6.4/assets/search.js
+++ b/en/v0.6.4/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title')
+        this.field('title', {boost: 10})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v0.6.4/assets/search.js
+++ b/en/v0.6.4/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title', {boost: 10})
+        this.field('title', {boost: 100})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v0.7.0/assets/search.js
+++ b/en/v0.7.0/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title')
+        this.field('title', {boost: 10})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v0.7.0/assets/search.js
+++ b/en/v0.7.0/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title', {boost: 10})
+        this.field('title', {boost: 100})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v1.0.0/assets/search.js
+++ b/en/v1.0.0/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title')
+        this.field('title', {boost: 10})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v1.0.0/assets/search.js
+++ b/en/v1.0.0/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title', {boost: 10})
+        this.field('title', {boost: 100})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v1.0.1/assets/search.js
+++ b/en/v1.0.1/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title')
+        this.field('title', {boost: 10})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v1.0.1/assets/search.js
+++ b/en/v1.0.1/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title', {boost: 10})
+        this.field('title', {boost: 100})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v1.0.2/assets/search.js
+++ b/en/v1.0.2/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title')
+        this.field('title', {boost: 10})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v1.0.2/assets/search.js
+++ b/en/v1.0.2/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title', {boost: 10})
+        this.field('title', {boost: 100})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v1.0.3/assets/search.js
+++ b/en/v1.0.3/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title')
+        this.field('title', {boost: 10})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v1.0.3/assets/search.js
+++ b/en/v1.0.3/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title', {boost: 10})
+        this.field('title', {boost: 100})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v1.0.4/assets/search.js
+++ b/en/v1.0.4/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title')
+        this.field('title', {boost: 10})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v1.0.4/assets/search.js
+++ b/en/v1.0.4/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title', {boost: 10})
+        this.field('title', {boost: 100})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v1.1-dev/assets/search.js
+++ b/en/v1.1-dev/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title')
+        this.field('title', {boost: 10})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v1.1-dev/assets/search.js
+++ b/en/v1.1-dev/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title', {boost: 10})
+        this.field('title', {boost: 100})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v1.1.0/assets/search.js
+++ b/en/v1.1.0/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title')
+        this.field('title', {boost: 10})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v1.1.0/assets/search.js
+++ b/en/v1.1.0/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title', {boost: 10})
+        this.field('title', {boost: 100})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v1.1.1/assets/search.js
+++ b/en/v1.1.1/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title')
+        this.field('title', {boost: 10})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v1.1.1/assets/search.js
+++ b/en/v1.1.1/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title', {boost: 10})
+        this.field('title', {boost: 100})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v1.2-dev/assets/search.js
+++ b/en/v1.2-dev/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title')
+        this.field('title', {boost: 10})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v1.2-dev/assets/search.js
+++ b/en/v1.2-dev/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title', {boost: 10})
+        this.field('title', {boost: 100})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v1.2.0/assets/search.js
+++ b/en/v1.2.0/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title')
+        this.field('title', {boost: 10})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v1.2.0/assets/search.js
+++ b/en/v1.2.0/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title', {boost: 10})
+        this.field('title', {boost: 100})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v1.3-dev/assets/search.js
+++ b/en/v1.3-dev/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title')
+        this.field('title', {boost: 10})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v1.3-dev/assets/search.js
+++ b/en/v1.3-dev/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title', {boost: 10})
+        this.field('title', {boost: 100})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v1.4-dev/assets/search.js
+++ b/en/v1.4-dev/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title')
+        this.field('title', {boost: 10})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)

--- a/en/v1.4-dev/assets/search.js
+++ b/en/v1.4-dev/assets/search.js
@@ -179,7 +179,7 @@ require(["jquery", "lunr", "lodash"], function($, lunr, _) {
 
     var index = lunr(function () {
         this.ref('location')
-        this.field('title', {boost: 10})
+        this.field('title', {boost: 100})
         this.field('text')
         documenterSearchIndex['docs'].forEach(function(e) {
             this.add(e)


### PR DESCRIPTION
Purely a suggestion as I know this breaks the strict no-PR rule for docs.

It would retroactively improve search ranking for title matches, in line with https://github.com/JuliaDocs/Documenter.jl/pull/1112