### PR TITLE
Remove old `release-*` page disallow statements

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,9 +1,2 @@
 User-agent: *
-# Exclude the old release-0.x directories. While they have since been
-# removed, they still show up on searches sometimes. Hopefully this will
-# cause them to be de-indexed.
-Disallow: /en/release-0.3/
-Disallow: /en/release-0.4/
-Disallow: /en/release-0.5/
-Disallow: /en/release-0.6/
 Sitemap: http://docs.julialang.org/sitemap.xml


### PR DESCRIPTION
As confirmed by google search console coverage tests, disallowing them prevents google from detecting that the pages have been removed. Better to not disallow.


