### PR TITLE
CI: set a timeout of 2 hours

### DIFF
--- a/.github/workflows/PDFs.yml
+++ b/.github/workflows/PDFs.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   pdf:
     name: Julia PDF builds (${{ matrix.buildtype }})
+    timeout-minutes: 120
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
The default GitHub Actions timeout (6 hours) is too long.