### PR TITLE
Upload LaTeX logs as artifacts 

### DIFF
--- a/.github/workflows/PDFs.yml
+++ b/.github/workflows/PDFs.yml
@@ -3,8 +3,9 @@ on:
   push:
     branches:
       - master
-  schedule:
-    - cron: '0 0 * * *' # daily
+      - mp/latex-logs
+  #schedule:
+    #- cron: '0 0 * * *' # daily
   pull_request:
   workflow_dispatch:
 jobs:
@@ -16,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         buildtype:
-          - 'releases'
+          #- 'releases'
           - 'nightly'
     env:
       BUILDROOT: ${{ github.workspace }}/pdf/build
@@ -47,6 +48,6 @@ jobs:
           DOCUMENTER_LATEX_DEBUG: latex-logs
       - run: tree
       - run: julia --color=yes pdf/make.jl commit
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY_PDF: ${{ secrets.DOCUMENTER_KEY_PDF }}
+        # env:
+        #   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        #   DOCUMENTER_KEY_PDF: ${{ secrets.DOCUMENTER_KEY_PDF }}

--- a/.github/workflows/PDFs.yml
+++ b/.github/workflows/PDFs.yml
@@ -43,6 +43,9 @@ jobs:
           git clone https://github.com/JuliaLang/julia.git $JULIA_SOURCE
           git clone https://github.com/JuliaLang/docs.julialang.org.git -b assets --single-branch $JULIA_DOCS
       - run: julia --color=yes pdf/make.jl ${{ matrix.buildtype }}
+        env:
+          DOCUMENTER_LATEX_DEBUG: latex-logs
+      - run: tree
       - run: julia --color=yes pdf/make.jl commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/PDFs.yml
+++ b/.github/workflows/PDFs.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
-          name: ${{ matrix.buildtype }} LaTeX source and logs
+          name: "LaTeX source and logs: ${{ matrix.buildtype }}"
           path: ${{ github.workspace }}/latex-debug-logs/
       - run: julia --color=yes pdf/make.jl commit
         env:

--- a/.github/workflows/PDFs.yml
+++ b/.github/workflows/PDFs.yml
@@ -47,9 +47,9 @@ jobs:
         env:
           DOCUMENTER_LATEX_DEBUG: latex-debug-logs
       - run: tree
-        if: always
+        if: ${{ always() }}
       - uses: actions/upload-artifact@v3
-        if: always
+        if: ${{ always() }}
         with:
           name: ${{ matrix.buildtype }} LaTeX source and logs
           path: pdf/latex-debug-logs/

--- a/.github/workflows/PDFs.yml
+++ b/.github/workflows/PDFs.yml
@@ -3,9 +3,8 @@ on:
   push:
     branches:
       - master
-      - mp/latex-logs
-  #schedule:
-    #- cron: '0 0 * * *' # daily
+  schedule:
+    - cron: '0 0 * * *' # daily
   pull_request:
   workflow_dispatch:
 jobs:
@@ -17,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         buildtype:
-          #- 'releases'
+          - 'releases'
           - 'nightly'
     env:
       BUILDROOT: ${{ github.workspace }}/pdf/build
@@ -54,6 +53,6 @@ jobs:
           name: ${{ matrix.buildtype }} LaTeX source and logs
           path: ${{ github.workspace }}/latex-debug-logs/
       - run: julia --color=yes pdf/make.jl commit
-        # env:
-        #   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        #   DOCUMENTER_KEY_PDF: ${{ secrets.DOCUMENTER_KEY_PDF }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY_PDF: ${{ secrets.DOCUMENTER_KEY_PDF }}

--- a/.github/workflows/PDFs.yml
+++ b/.github/workflows/PDFs.yml
@@ -45,8 +45,6 @@ jobs:
       - run: julia --color=yes pdf/make.jl ${{ matrix.buildtype }}
         env:
           DOCUMENTER_LATEX_DEBUG: ${{ github.workspace }}/latex-debug-logs
-      - run: tree
-        if: ${{ always() }}
       - uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:

--- a/.github/workflows/PDFs.yml
+++ b/.github/workflows/PDFs.yml
@@ -48,8 +48,9 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
-          name: "LaTeX source and logs: ${{ matrix.buildtype }}"
+          name: "LaTeX source and logs (${{ matrix.buildtype }})"
           path: ${{ github.workspace }}/latex-debug-logs/
+          retention-days: 7 # reduced from the default 90, builds run daily anyway
       - run: julia --color=yes pdf/make.jl commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/PDFs.yml
+++ b/.github/workflows/PDFs.yml
@@ -45,8 +45,14 @@ jobs:
           git clone https://github.com/JuliaLang/docs.julialang.org.git -b assets --single-branch $JULIA_DOCS
       - run: julia --color=yes pdf/make.jl ${{ matrix.buildtype }}
         env:
-          DOCUMENTER_LATEX_DEBUG: latex-logs
+          DOCUMENTER_LATEX_DEBUG: latex-debug-logs
       - run: tree
+        if: always
+      - uses: actions/upload-artifact@v3
+        if: always
+        with:
+          name: ${{ matrix.buildtype }} LaTeX source and logs
+          path: pdf/latex-debug-logs/
       - run: julia --color=yes pdf/make.jl commit
         # env:
         #   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/PDFs.yml
+++ b/.github/workflows/PDFs.yml
@@ -45,14 +45,14 @@ jobs:
           git clone https://github.com/JuliaLang/docs.julialang.org.git -b assets --single-branch $JULIA_DOCS
       - run: julia --color=yes pdf/make.jl ${{ matrix.buildtype }}
         env:
-          DOCUMENTER_LATEX_DEBUG: latex-debug-logs
+          DOCUMENTER_LATEX_DEBUG: ${{ github.workspace }}/latex-debug-logs
       - run: tree
         if: ${{ always() }}
       - uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
           name: ${{ matrix.buildtype }} LaTeX source and logs
-          path: pdf/latex-debug-logs/
+          path: ${{ github.workspace }}/latex-debug-logs/
       - run: julia --color=yes pdf/make.jl commit
         # env:
         #   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Requires JuliaDocs/Documenter.jl#1806 to actually produce useful logs, but the uploading part should work already now.