### PR TITLE
Build PDFs for beta pre-releases too

### DIFF
--- a/pdf/make.jl
+++ b/pdf/make.jl
@@ -13,8 +13,12 @@ function download_release(v::VersionNumber)
         julia = "julia-$(v)-linux-x86_64"
         tarball = "$(julia).tar.gz"
         sha256 = "julia-$(v).sha256"
-        run(`curl -vo $(tarball) -L https://julialang-s3.julialang.org/bin/linux/x64/$(x).$(y)/$(tarball)`)
-        run(`curl -vo $(sha256) -L https://julialang-s3.julialang.org/bin/checksums/$(sha256)`)
+        url = https://julialang-s3.julialang.org/bin/linux/x64/$(x).$(y)/$(tarball)
+        sha_url = https://julialang-s3.julialang.org/bin/checksums/$(sha256)
+        @info "Downloading release" url sha_url
+        run(`curl -vo $(tarball) -L $(url)`)
+        run(`curl -vo $(sha256) -L $(sha_url)`)
+        @info "Contents of SHA256 file:\n$(read(sha256, String))"
         run(pipeline(`grep $(tarball) $(sha256)`, `sha256sum -c`))
         mkpath(julia)
         run(`tar -xzf $(tarball) -C $(julia) --strip-components 1`)
@@ -27,7 +31,9 @@ function download_nightly()
     julia_exec, commit = cd(BUILDROOT) do
         julia = "julia-latest-linux64"
         tarball = "$(julia).tar.gz"
-        run(`curl -vo $(tarball) -L https://julialangnightlies-s3.julialang.org/bin/linux/x64/$(tarball)`)
+        url = https://julialangnightlies-s3.julialang.org/bin/linux/x64/$(tarball)
+        @info "Downloading nightly" url
+        run(`curl -vo $(tarball) -L $url`)
         # find the commit from the extracted folder
         folder = first(readlines(`tar -tf $(tarball)`))
         _, commit = split(folder, '-'); commit = chop(commit)

--- a/pdf/make.jl
+++ b/pdf/make.jl
@@ -13,8 +13,8 @@ function download_release(v::VersionNumber)
         julia = "julia-$(v)-linux-x86_64"
         tarball = "$(julia).tar.gz"
         sha256 = "julia-$(v).sha256"
-        url = https://julialang-s3.julialang.org/bin/linux/x64/$(x).$(y)/$(tarball)
-        sha_url = https://julialang-s3.julialang.org/bin/checksums/$(sha256)
+        url = "https://julialang-s3.julialang.org/bin/linux/x64/$(x).$(y)/$(tarball)"
+        sha_url = "https://julialang-s3.julialang.org/bin/checksums/$(sha256)"
         @info "Downloading release" url sha_url
         run(`curl -vo $(tarball) -L $(url)`)
         run(`curl -vo $(sha256) -L $(sha_url)`)
@@ -31,7 +31,7 @@ function download_nightly()
     julia_exec, commit = cd(BUILDROOT) do
         julia = "julia-latest-linux64"
         tarball = "$(julia).tar.gz"
-        url = https://julialangnightlies-s3.julialang.org/bin/linux/x64/$(tarball)
+        url = "https://julialangnightlies-s3.julialang.org/bin/linux/x64/$(tarball)"
         @info "Downloading nightly" url
         run(`curl -vo $(tarball) -L $url`)
         # find the commit from the extracted folder

--- a/pdf/make.jl
+++ b/pdf/make.jl
@@ -120,9 +120,10 @@ function collect_versions()
         # lines are in the form 'COMMITSHA\trefs/tags/TAG'
         _, ref = split(line, '\t')
         _, _, tag = split(ref, '/')
-        if occursin(r"^v\d+\.\d+\.\d+(?:-rc\d+)?$", tag)
+        if occursin(r"^v\d+\.\d+\.\d+(?:-(:?rc|beta)\d+)?$", tag)
             # the version regex is not as general as Base.VERSION_REGEX -- we only build "pure"
-            # versions and exclude tags that are pre-releases or have build information.
+            # versions and exclude tags that are pre-releases (except for -rcN and -betaN) or
+            # have build information.
             v = VersionNumber(tag)
             # pdf doc only possible for 1.1.0 and above
             v >= v"1.1.0" || continue


### PR DESCRIPTION
We build the HTML (e.g. https://docs.julialang.org/en/v1.9.0-beta4/), but the PDFs are missing right now.