### PR TITLE
Update `actions/{cache,checkout,upload-artifact}`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/PDFs.yml
+++ b/.github/workflows/PDFs.yml
@@ -23,12 +23,12 @@ jobs:
       JULIA_SOURCE: ${{ github.workspace }}/pdf/build/julia
       JULIA_DOCS: ${{ github.workspace }}/pdf/build/docs.julialang.org
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
           version: 1
           show-versioninfo: true
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/.github/workflows/PDFs.yml
+++ b/.github/workflows/PDFs.yml
@@ -45,7 +45,7 @@ jobs:
       - run: julia --color=yes pdf/make.jl ${{ matrix.buildtype }}
         env:
           DOCUMENTER_LATEX_DEBUG: ${{ github.workspace }}/latex-debug-logs
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: "LaTeX source and logs (${{ matrix.buildtype }})"


### PR DESCRIPTION
The [CI job is currently failing](https://github.com/JuliaLang/docs.julialang.org/actions/workflows/PDFs.yml) due to the following error:

> Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v1`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down. This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Also:

> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

I believe this is also the reason of [JuliaLang/julia#58037 ](https://github.com/JuliaLang/julia/issues/58037)