### PR TITLE
Fix PDF build by passing stdlibdir from downloaded binary

### DIFF
--- a/.github/workflows/PDFs.yml
+++ b/.github/workflows/PDFs.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   pdf:
     name: Julia PDF builds (${{ matrix.buildtype }})
-    timeout-minutes: 120
+    timeout-minutes: 180
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/pdf/make.jl
+++ b/pdf/make.jl
@@ -49,11 +49,14 @@ function download_nightly()
 end
 
 function makedocs(julia_exec)
+    # Override build_datarootdir so the Makefile's stdlibdir points to the downloaded binary's stdlib.
+    stdlibdir = readchomp(`$(julia_exec) -e 'print(Sys.STDLIB)'`)
+    datarootdir = abspath(joinpath(stdlibdir, "..", "..", ".."))
     @sync begin
         builder = @async begin
             withenv("DOCUMENTER_KEY" => nothing, # skips deploydocs with the BuildBotConfig (see doc/make.jl)
                     "BUILDROOT" => nothing) do
-                run(`make -C $(JULIA_SOURCE)/doc pdf texplatform=docker JULIA_EXECUTABLE=$(julia_exec)`)
+                run(`make -C $(JULIA_SOURCE)/doc pdf texplatform=docker JULIA_EXECUTABLE=$(julia_exec) build_datarootdir=$(datarootdir)`)
             end
         end
         @async begin


### PR DESCRIPTION
## Summary

- The daily PDF build has been broken since May 2025 (JuliaLang/julia#61122)
- Root cause: JuliaLang/julia#58574 added `stdlibdir=...` to `doc/Makefile`'s `DOCUMENTER_OPTIONS`, pointing to the build tree path (`julia/usr/share/julia/stdlib/vX.Y/`). This path doesn't exist when the source tree is only cloned (not built), as is the case in this CI workflow.
- Fix: Query `Sys.STDLIB` from the downloaded Julia binary and pass it explicitly as `stdlibdir` to the `make` command, overriding the Makefile's default.

## Test plan

- [ ] Verify the nightly CI run succeeds after merge
- [ ] Verify the releases CI run succeeds (it will only build new releases not already on the assets branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)