### PR TITLE
Switch from Docker to native TeX Live for PDF builds

### DIFF
--- a/.github/workflows/PDFs.yml
+++ b/.github/workflows/PDFs.yml
@@ -28,16 +28,20 @@ jobs:
         with:
           version: 1
           show-versioninfo: true
-      - uses: actions/cache@v5
-        env:
-          cache-name: cache-artifacts
+      - name: Cache Julia artifacts
+        uses: actions/cache@v5
         with:
           path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          key: ${{ runner.os }}-julia-artifacts-${{ hashFiles('**/Project.toml') }}
           restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+            ${{ runner.os }}-julia-artifacts-
+      - name: Install TeX Live and Pygments
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            texlive-luatex texlive-latex-extra texlive-fonts-extra \
+            texlive-fonts-recommended texlive-plain-generic \
+            latexmk python3-pygments fonts-dejavu
       - run: |
           mkdir $BUILDROOT
           git clone https://github.com/JuliaLang/julia.git $JULIA_SOURCE

--- a/.github/workflows/PDFs.yml
+++ b/.github/workflows/PDFs.yml
@@ -32,9 +32,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            texlive-luatex texlive-latex-extra texlive-fonts-extra \
-            texlive-fonts-recommended texlive-plain-generic \
-            latexmk python3-pygments fonts-dejavu
+            texlive-latex-base texlive-luatex texlive-latex-recommended \
+            texlive-latex-extra texlive-fonts-extra texlive-fonts-recommended \
+            texlive-plain-generic latexmk \
+            python3-pygments fontconfig fonts-dejavu fonts-lato
       - run: |
           mkdir $BUILDROOT
           git clone https://github.com/JuliaLang/julia.git $JULIA_SOURCE

--- a/.github/workflows/PDFs.yml
+++ b/.github/workflows/PDFs.yml
@@ -28,13 +28,6 @@ jobs:
         with:
           version: 1
           show-versioninfo: true
-      - name: Cache Julia artifacts
-        uses: actions/cache@v5
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-julia-artifacts-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-julia-artifacts-
       - name: Install TeX Live and Pygments
         run: |
           sudo apt-get update

--- a/.github/workflows/PDFs.yml
+++ b/.github/workflows/PDFs.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install TeX Live and Pygments
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          sudo apt-get install -y \
             texlive-luatex texlive-latex-extra texlive-fonts-extra \
             texlive-fonts-recommended texlive-plain-generic \
             latexmk python3-pygments fonts-dejavu

--- a/pdf/make.jl
+++ b/pdf/make.jl
@@ -56,7 +56,7 @@ function makedocs(julia_exec)
         builder = @async begin
             withenv("DOCUMENTER_KEY" => nothing, # skips deploydocs with the BuildBotConfig (see doc/make.jl)
                     "BUILDROOT" => nothing) do
-                run(`make -C $(JULIA_SOURCE)/doc pdf texplatform=docker JULIA_EXECUTABLE=$(julia_exec) build_datarootdir=$(datarootdir)`)
+                run(`make -C $(JULIA_SOURCE)/doc pdf JULIA_EXECUTABLE=$(julia_exec) build_datarootdir=$(datarootdir)`)
             end
         end
         @async begin


### PR DESCRIPTION
## Summary

- Replace the `juliadocs/documenter-latex:0.1` Docker image (last updated December 2018) with a native TeX Live installation from Ubuntu's apt repository
- Uses `texplatform=native` (Documenter's `latexmk` mode) instead of `texplatform=docker`
- Installs only the required TeX Live packages: `texlive-luatex`, `texlive-latex-extra`, `texlive-fonts-extra`, `texlive-fonts-recommended`, `texlive-plain-generic`, `latexmk`, `python3-pygments`, `fonts-dejavu`
- Also bumps job timeout from 120 to 180 minutes (inherited from #39)

Depends on #39 (stdlibdir fix).

## Test plan

- [ ] Verify nightly CI passes with native TeX Live
- [ ] Verify releases CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)