### PR TITLE
Parallelize PDF builds with reliability and performance improvements

### DIFF
--- a/.github/actions/setup-pdf-build/action.yml
+++ b/.github/actions/setup-pdf-build/action.yml
@@ -1,0 +1,48 @@
+name: Setup PDF build environment
+description: Install Julia, TeX Live, and clone Julia source
+
+inputs:
+  clone-assets:
+    description: Also clone the docs.julialang.org assets branch
+    default: 'false'
+  julia-ref:
+    description: Git ref to checkout (e.g. v1.12.5). If empty, does a shallow clone of the default branch.
+    default: ''
+runs:
+  using: composite
+  steps:
+    - uses: julia-actions/setup-julia@v2
+      with:
+        version: 1
+        show-versioninfo: true
+    - uses: TeX-Live/setup-texlive-action@v4
+      with:
+        version: latest
+        packages: |
+          scheme-basic
+          collection-luatex
+          collection-latexrecommended
+          collection-latexextra
+          collection-fontsextra
+          collection-fontsrecommended
+          collection-plaingeneric
+          latexmk
+          minted
+    - name: Install system dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y python3-pygments fontconfig fonts-dejavu fonts-lato
+    - uses: julia-actions/cache@v3
+    - name: Clone repositories
+      shell: bash
+      run: |
+        mkdir -p $BUILDROOT
+        if [ -n "${{ inputs.julia-ref }}" ]; then
+          git clone --depth 1 --branch "${{ inputs.julia-ref }}" https://github.com/JuliaLang/julia.git $JULIA_SOURCE
+        else
+          git clone --depth 1 https://github.com/JuliaLang/julia.git $JULIA_SOURCE
+        fi
+        if [ "${{ inputs.clone-assets }}" = "true" ]; then
+          git clone https://github.com/JuliaLang/docs.julialang.org.git -b assets --single-branch $JULIA_DOCS
+        fi

--- a/.github/workflows/PDFs.yml
+++ b/.github/workflows/PDFs.yml
@@ -7,50 +7,101 @@ on:
     - cron: '0 0 * * *' # daily
   pull_request:
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+env:
+  BUILDROOT: ${{ github.workspace }}/pdf/build
+  JULIA_SOURCE: ${{ github.workspace }}/pdf/build/julia
+  JULIA_DOCS: ${{ github.workspace }}/pdf/build/docs.julialang.org
+
 jobs:
-  pdf:
-    name: Julia PDF builds (${{ matrix.buildtype }})
-    timeout-minutes: 180
+  # Determine which versions need PDF builds (missing releases + nightly)
+  collect-versions:
+    name: Collect versions to build
     runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.versions.outputs.versions }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-pdf-build
+        with:
+          clone-assets: 'true'
+      - id: versions
+        run: |
+          versions=$(julia --color=yes -e '
+            include("pdf/make.jl")
+            versions = collect_versions()
+            sort!(versions)
+            targets = String[]
+            for v in versions
+              file = "julia-$(v).pdf"
+              if !isfile("$(ENV["JULIA_DOCS"])/$(file)")
+                push!(targets, string(v))
+              end
+            end
+            push!(targets, "nightly")
+            print("[")
+            print(join(["\"$t\"" for t in targets], ","))
+            print("]")
+          ')
+          echo "versions=$versions" >> "$GITHUB_OUTPUT"
+          echo "Versions to build: $versions"
+
+  # Build each version in parallel
+  build-pdf:
+    name: PDF ${{ matrix.version }}
+    needs: collect-versions
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        buildtype:
-          - 'releases'
-          - 'nightly'
-    env:
-      BUILDROOT: ${{ github.workspace }}/pdf/build
-      JULIA_SOURCE: ${{ github.workspace }}/pdf/build/julia
-      JULIA_DOCS: ${{ github.workspace }}/pdf/build/docs.julialang.org
+        version: ${{ fromJson(needs.collect-versions.outputs.versions) }}
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: ./.github/actions/setup-pdf-build
         with:
-          version: 1
-          show-versioninfo: true
-      - uses: actions/cache@v5
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
-      - run: |
-          mkdir $BUILDROOT
-          git clone https://github.com/JuliaLang/julia.git $JULIA_SOURCE
-          git clone https://github.com/JuliaLang/docs.julialang.org.git -b assets --single-branch $JULIA_DOCS
-      - run: julia --color=yes pdf/make.jl ${{ matrix.buildtype }}
+          julia-ref: ${{ matrix.version != 'nightly' && format('v{0}', matrix.version) || '' }}
+      - run: julia --color=yes pdf/make.jl build ${{ matrix.version }}
         env:
           DOCUMENTER_LATEX_DEBUG: ${{ github.workspace }}/latex-debug-logs
       - uses: actions/upload-artifact@v7
         if: ${{ always() }}
         with:
-          name: "LaTeX source and logs (${{ matrix.buildtype }})"
+          name: "LaTeX source and logs (${{ matrix.version }})"
           path: ${{ github.workspace }}/latex-debug-logs/
-          retention-days: 7 # reduced from the default 90, builds run daily anyway
+          retention-days: 7
+      - uses: actions/upload-artifact@v7
+        with:
+          name: "pdf-${{ matrix.version }}"
+          path: ${{ env.BUILDROOT }}/tmp/julia-*.pdf
+          retention-days: 7
+
+  # Commit all built PDFs to the assets branch
+  commit-pdfs:
+    name: Commit PDFs to assets branch
+    needs: [build-pdf]
+    if: ${{ always() && github.event_name != 'pull_request' && contains(fromJson('["success", "failure"]'), needs.build-pdf.result) }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: 1
+      - run: |
+          mkdir -p $BUILDROOT/tmp
+          git clone https://github.com/JuliaLang/docs.julialang.org.git -b assets --single-branch $JULIA_DOCS
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: pdf-*
+          path: ${{ env.BUILDROOT }}/tmp/
+          merge-multiple: true
+      - run: |
+          echo "Downloaded PDFs:"
+          ls -lh $BUILDROOT/tmp/*.pdf 2>/dev/null || echo "No PDFs found"
       - run: julia --color=yes pdf/make.jl commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pdf/make.jl
+++ b/pdf/make.jl
@@ -6,6 +6,8 @@ const JULIA_SOURCE   = get(ENV, "JULIA_SOURCE", "$(BUILDROOT)/julia")
 const JULIA_DOCS     = get(ENV, "JULIA_DOCS", "$(BUILDROOT)/docs.julialang.org")
 const JULIA_DOCS_TMP = get(ENV, "JULIA_DOCS_TMP", "$(BUILDROOT)/tmp")
 
+const MIN_PDF_SIZE = 1_000_000 # 1 MB minimum for a valid Julia manual PDF
+
 # download and extract binary for a given version, return path to executable
 function download_release(v::VersionNumber)
     x, y = v.major, v.minor
@@ -16,8 +18,8 @@ function download_release(v::VersionNumber)
         url = "https://julialang-s3.julialang.org/bin/linux/x64/$(x).$(y)/$(tarball)"
         sha_url = "https://julialang-s3.julialang.org/bin/checksums/$(sha256)"
         @info "Downloading release tarball." url sha_url
-        run(`curl -fvo $(tarball) -L $(url)`)
-        run(`curl -fvo $(sha256) -L $(sha_url)`)
+        run(`curl --retry 5 --retry-delay 10 -fvo $(tarball) -L $(url)`)
+        run(`curl --retry 5 --retry-delay 10 -fvo $(sha256) -L $(sha_url)`)
         try
             run(pipeline(`grep $(tarball) $(sha256)`, `sha256sum -c`))
         catch e
@@ -37,7 +39,7 @@ function download_nightly()
         tarball = "$(julia).tar.gz"
         url = "https://julialangnightlies-s3.julialang.org/bin/linux/x64/$(tarball)"
         @info "Downloading nightly tarball." url
-        run(`curl -fvo $(tarball) -L $url`)
+        run(`curl --retry 5 --retry-delay 10 -fvo $(tarball) -L $url`)
         # find the commit from the extracted folder
         folder = first(readlines(`tar -tf $(tarball)`))
         _, commit = split(folder, '-'); commit = chop(commit)
@@ -56,7 +58,7 @@ function makedocs(julia_exec)
         builder = @async begin
             withenv("DOCUMENTER_KEY" => nothing, # skips deploydocs with the BuildBotConfig (see doc/make.jl)
                     "BUILDROOT" => nothing) do
-                run(`make -C $(JULIA_SOURCE)/doc pdf texplatform=docker JULIA_EXECUTABLE=$(julia_exec) build_datarootdir=$(datarootdir)`)
+                run(`make -C $(JULIA_SOURCE)/doc pdf JULIA_EXECUTABLE=$(julia_exec) build_datarootdir=$(datarootdir)`)
             end
         end
         @async begin
@@ -68,6 +70,21 @@ function makedocs(julia_exec)
     end
 end
 
+function validate_pdf(path)
+    if !isfile(path)
+        error("PDF not found: $path")
+    end
+    size = filesize(path)
+    if size < MIN_PDF_SIZE
+        error("PDF too small ($(size) bytes): $path — likely corrupted or incomplete")
+    end
+    header = open(io -> read(io, 5), path)
+    if header != UInt8['%', 'P', 'D', 'F', '-']
+        error("Not a valid PDF (bad header): $path")
+    end
+    @info "PDF validated." path size_mb=round(size / 1_000_000; digits=1)
+end
+
 function copydocs(file)
     isdir(JULIA_DOCS_TMP) || mkpath(JULIA_DOCS_TMP)
     output = "$(JULIA_SOURCE)/doc/_build/pdf/en"
@@ -75,19 +92,21 @@ function copydocs(file)
     for f in readdir(output)
         if startswith(f, "TheJuliaLanguage") && endswith(f, ".pdf")
             cp("$(output)/$(f)", destination; force=true)
+            validate_pdf(destination)
             @info "finished, output file copied to $(destination)."
-            break
+            return
         end
     end
+    error("No PDF found in $(output)")
 end
 
-function build_release_pdf(v::VersionNumber)
+function build_release_pdf(v::VersionNumber; skip_existing::Bool=true, checkout::Bool=true)
     @info "building PDF for Julia v$(v)."
 
     file = "julia-$(v).pdf"
 
     # early return if file exists
-    if isfile("$(JULIA_DOCS)/$(file)")
+    if skip_existing && isfile("$(JULIA_DOCS)/$(file)")
         @info "PDF for Julia v$(v) already exists, skipping."
         return
     end
@@ -95,9 +114,11 @@ function build_release_pdf(v::VersionNumber)
     # download julia binary
     julia_exec = download_release(v)
 
-    # checkout relevant tag and clean repo
-    run(`git -C $(JULIA_SOURCE) checkout v$(v)`)
-    run(`git -C $(JULIA_SOURCE) clean -fdx`)
+    # checkout relevant tag and clean repo (skip if already at the right ref via shallow clone)
+    if checkout
+        run(`git -C $(JULIA_SOURCE) checkout v$(v)`)
+        run(`git -C $(JULIA_SOURCE) clean -fdx`)
+    end
 
     # invoke makedocs
     makedocs(julia_exec)
@@ -112,7 +133,8 @@ function build_nightly_pdf()
     _, _, v = split(readchomp(`$(julia_exec) --version`))
     @info "commit determined to $(commit) and version determined to $(v)."
 
-    # checkout correct commit and clean repo
+    # fetch and checkout the nightly commit (shallow clone may not have it)
+    run(`git -C $(JULIA_SOURCE) fetch --depth 1 origin $(commit)`)
     run(`git -C $(JULIA_SOURCE) checkout $(commit)`)
     run(`git -C $(JULIA_SOURCE) clean -fdx`)
 
@@ -131,19 +153,15 @@ function collect_versions()
         # lines are in the form 'COMMITSHA\trefs/tags/TAG'
         _, ref = split(line, '\t')
         _, _, tag = split(ref, '/')
-        if occursin(r"^v\d+\.\d+\.\d+(?:-(:?rc|beta)\d+)?$", tag)
-            # the version regex is not as general as Base.VERSION_REGEX -- we only build "pure"
-            # versions and exclude tags that are pre-releases (except for -rcN and -betaN) or
-            # have build information.
+        if occursin(r"^v\d+\.\d+\.\d+(?:-(:?alpha|beta|rc)\d+)?$", tag)
+            # the version regex is not as general as Base.VERSION_REGEX -- we only build
+            # release and pre-release versions (alpha, beta, rc) but exclude tags with
+            # build information or non-standard pre-release labels.
             v = VersionNumber(tag)
             # pdf doc only possible for 1.1.0 and above
             v >= v"1.1.0" || continue
-            # only build RCs if > 1.7
-            v < v"1.7.0" && !isempty(v.prerelease) && continue
-            # exclude 1.8.0 pre-releases, since those fail
-            v"1.8.0-" < v < v"1.8.0" && continue
-            # exclude 1.9.0-beta1, because it doesn't have a SHA file
-            v == v"1.9.0-beta1" && continue
+            # only build pre-releases for 1.10+
+            (v.major, v.minor) < (1, 10) && !isempty(v.prerelease) && continue
             push!(versions, v)
         end
     end
@@ -156,8 +174,8 @@ function commit()
         @info "skipping commit from pull requests."
         return
     end
-    if !isdir(JULIA_DOCS_TMP)
-        @info "No new PDFs created, skipping commit."
+    if !isdir(JULIA_DOCS_TMP) || isempty(filter(f -> endswith(f, ".pdf"), readdir(JULIA_DOCS_TMP)))
+        @info "No new PDFs found, skipping commit."
         return
     end
     @info "committing built PDF files."
@@ -207,6 +225,16 @@ function main()
     if "releases" in ARGS
         @info "building PDFs for all applicable Julia releases."
         foreach(build_release_pdf, collect_versions())
+    elseif "build" in ARGS
+        # Build a single version (used by parallel CI jobs with shallow clones)
+        idx = findfirst(==("build"), ARGS)
+        idx < length(ARGS) || error("usage: make.jl build <version|nightly>")
+        target = ARGS[idx + 1]
+        if target == "nightly"
+            build_nightly_pdf()
+        else
+            build_release_pdf(VersionNumber(target); skip_existing=false, checkout=false)
+        end
     elseif "nightly" in ARGS
         @info "building PDF for Julia nightly."
         build_nightly_pdf()

--- a/pdf/make.jl
+++ b/pdf/make.jl
@@ -9,6 +9,7 @@ const JULIA_DOCS_TMP = get(ENV, "JULIA_DOCS_TMP", "$(BUILDROOT)/tmp")
 const MIN_PDF_SIZE = 1_000_000 # 1 MB minimum for a valid Julia manual PDF
 
 # download and extract binary for a given version, return path to executable
+# returns nothing if the binary is not available (e.g. tag exists but release was never published)
 function download_release(v::VersionNumber)
     x, y = v.major, v.minor
     julia_exec = cd(BUILDROOT) do
@@ -17,6 +18,11 @@ function download_release(v::VersionNumber)
         sha256 = "julia-$(v).sha256"
         url = "https://julialang-s3.julialang.org/bin/linux/x64/$(x).$(y)/$(tarball)"
         sha_url = "https://julialang-s3.julialang.org/bin/checksums/$(sha256)"
+        # check that the binary exists before downloading
+        if !success(`curl --retry 3 --retry-delay 5 -sfI -o /dev/null $(url)`)
+            @warn "Binary not available for Julia v$(v), skipping." url
+            return nothing
+        end
         @info "Downloading release tarball." url sha_url
         run(`curl --retry 5 --retry-delay 10 -fvo $(tarball) -L $(url)`)
         run(`curl --retry 5 --retry-delay 10 -fvo $(sha256) -L $(sha_url)`)
@@ -40,12 +46,12 @@ function download_nightly()
         url = "https://julialangnightlies-s3.julialang.org/bin/linux/x64/$(tarball)"
         @info "Downloading nightly tarball." url
         run(`curl --retry 5 --retry-delay 10 -fvo $(tarball) -L $url`)
-        # find the commit from the extracted folder
-        folder = first(readlines(`tar -tf $(tarball)`))
-        _, commit = split(folder, '-'); commit = chop(commit)
         mkpath(julia)
         run(`tar -xzf $(tarball) -C $(julia) --strip-components 1`)
-        return abspath(julia, "bin", "julia"), commit
+        exec = abspath(julia, "bin", "julia")
+        # get the full commit hash from the binary (tarball folder only has a short hash)
+        commit = readchomp(`$(exec) -e 'print(Base.GIT_VERSION_INFO.commit)'`)
+        return exec, commit
     end
     return julia_exec, commit
 end
@@ -111,8 +117,12 @@ function build_release_pdf(v::VersionNumber; skip_existing::Bool=true, checkout:
         return
     end
 
-    # download julia binary
+    # download julia binary (returns nothing if binary not available on S3)
     julia_exec = download_release(v)
+    if julia_exec === nothing
+        @info "No binary available for Julia v$(v), skipping PDF build."
+        return
+    end
 
     # checkout relevant tag and clean repo (skip if already at the right ref via shallow clone)
     if checkout


### PR DESCRIPTION
## Summary

Redesigns the CI pipeline from a single sequential job into parallel per-version builds. Also replaces the ancient Docker image with native TeX Live.

- **Parallel builds**: `collect-versions` finds missing releases + nightly, then each builds as a separate matrix job (60 min timeout) via `make.jl build <version|nightly>`
- **Composite action** (`.github/actions/setup-pdf-build`): shared setup for Julia, TeX Live (latest, with minted v3 for better caching), system fonts, and shallow repo cloning
- **Caching**: TeX Live cached via `setup-texlive-action` (warmed by collect-versions), Julia depot cached via `julia-actions/cache`
- **Artifacts**: Built PDFs uploaded as 7-day artifacts for recovery if the commit step fails
- **Reliability**: curl retries on S3 downloads, PDF validation (size + header check), commit step tolerates partial build failures
- **Pre-releases**: alpha/beta/rc included for Julia 1.10+
- **Concurrency**: Stale PR runs auto-cancelled

## Architecture

```
collect-versions (warms caches, outputs JSON matrix)
  │
  ▼
build-pdf (parallel: one job per version, shallow clones)
  ├── PDF 1.12.5       ─┬─► upload pdf + debug artifacts
  ├── PDF 1.13.0-beta2  │
  └── PDF nightly       ┘
                         │
  ▼
commit-pdfs (downloads artifacts, pushes to assets branch)
```

## Test plan
- [ ] collect-versions outputs correct JSON (missing releases + nightly)
- [ ] Parallel build jobs hit TeX Live cache (not reinstalling)
- [ ] At least one release PDF builds and uploads as artifact
- [ ] Nightly PDF builds with correct commit checkout
- [ ] commit-pdfs downloads and lists built PDFs
- [ ] commit step skipped on pull_request events
- [ ] Partial failures: successful PDFs still committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)