### PR TITLE
Ignore missing PDF artifacts for skipped builds

### DIFF
--- a/.github/workflows/PDFs.yml
+++ b/.github/workflows/PDFs.yml
@@ -55,7 +55,7 @@ jobs:
     name: PDF ${{ matrix.version }}
     needs: collect-versions
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -78,6 +78,7 @@ jobs:
         with:
           name: "pdf-${{ matrix.version }}"
           path: ${{ env.BUILDROOT }}/tmp/julia-*.pdf
+          if-no-files-found: ignore
           retention-days: 7
 
   # Commit all built PDFs to the assets branch


### PR DESCRIPTION
## Summary
- Adds `if-no-files-found: ignore` to the PDF artifact upload step: when a release tag exists but no binary is available on S3 (e.g. `v1.13.0-alpha1`), the build job exits successfully with a skip message but produces no PDF — without this flag, `upload-artifact` would error on the missing file
- Reduces per-job timeout from 60 to 30 minutes: successful builds complete in ~10 minutes, 30 minutes catches stuck jobs faster while saving CI minutes
- Follow-up to #41

## Test plan
- [x] Verified in #41 CI run: `PDF 1.13.0-alpha1` passed with skip message, all other builds succeeded
- [x] All successful builds completed well within 30 minutes (~10 min each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)