### PR TITLE
Fix git add failing when no .commit files exist

### DIFF
--- a/pdf/make.jl
+++ b/pdf/make.jl
@@ -272,8 +272,11 @@ function commit()
         run(`git config user.email "documenter@juliadocs.github.io"`)
         run(`git remote set-url origin git@github.com:JuliaLang/docs.julialang.org.git`)
         run(`git config core.sshCommand "ssh -F $(sshconfig)"`)
-        # Committing all .pdf and .commit files
-        run(`git add '*.pdf' '*.commit'`)
+        # Stage all .pdf and .commit files
+        for ext in ("pdf", "commit")
+            files = filter(f -> endswith(f, ".$ext"), readdir("."))
+            isempty(files) || run(`git add $(files...)`)
+        end
         run(`git commit --amend --date=now -m "PDF versions of Julia's manual."`)
         # Push
         run(`git push -f origin assets`)


### PR DESCRIPTION
## Summary
Fixes the commit-pdfs job failure from #45: `git add '*.pdf' '*.commit'` errors when no `.commit` files are present (e.g. when only release PDFs were built and nightlies were unchanged).

Stages files by extension using `readdir()` so empty globs are skipped.

## Test plan
- [x] Reproduces: https://github.com/JuliaLang/docs.julialang.org/actions/runs/23080189026/job/67048664480
- [ ] commit-pdfs job succeeds when only PDFs (no .commit files) are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)