### PR TITLE
Only stage new/changed PDFs instead of all PDFs

### DIFF
--- a/pdf/make.jl
+++ b/pdf/make.jl
@@ -242,8 +242,9 @@ function commit()
         run(`git config user.email "documenter@juliadocs.github.io"`)
         run(`git remote set-url origin git@github.com:JuliaLang/docs.julialang.org.git`)
         run(`git config core.sshCommand "ssh -F $(sshconfig)"`)
-        # Stage new/updated PDFs
-        run(`git add '*.pdf'`)
+        # Stage only the new/updated PDFs
+        new_pdfs = filter(f -> endswith(f, ".pdf"), readdir(JULIA_DOCS_TMP))
+        isempty(new_pdfs) || run(`git add $new_pdfs`)
         # Clean up DEV PDFs that now have a corresponding release PDF
         for file in readdir(".")
             m = match(r"^julia-(.+)-DEV\.pdf$", file)


### PR DESCRIPTION
## Summary
Stage only files from `JULIA_DOCS_TMP` (build artifacts) instead of globbing all `*.pdf` in the assets checkout. On a typical daily run this stages just the nightly PDF instead of all 130+ files.

## Test plan
- [ ] commit-pdfs job succeeds
- [ ] Only the nightly PDF is touched in the assets commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)