### PR TITLE
Remove DEV PDF cleanup logic

### DIFF
--- a/pdf/make.jl
+++ b/pdf/make.jl
@@ -245,16 +245,6 @@ function commit()
         # Stage only the new/updated PDFs
         new_pdfs = filter(f -> endswith(f, ".pdf"), readdir(JULIA_DOCS_TMP))
         isempty(new_pdfs) || run(`git add $new_pdfs`)
-        # Clean up DEV PDFs that now have a corresponding release PDF
-        for file in readdir(".")
-            m = match(r"^julia-(.+)-DEV\.pdf$", file)
-            m === nothing && continue
-            release_pdf = "julia-$(m.captures[1]).pdf"
-            if isfile(release_pdf)
-                @info "Removing obsolete DEV PDF" file release_pdf
-                run(`git rm -f $file`)
-            end
-        end
         # Only commit and push if there are staged changes
         if success(`git diff --cached --quiet`)
             @info "No changes to commit."


### PR DESCRIPTION
## Summary

Removes the DEV PDF cleanup that incorrectly deleted historical DEV PDFs from the assets branch.

The cleanup matched `julia-X.Y.Z-DEV.pdf` against `julia-X.Y.Z.pdf` and removed the DEV file. This deleted `julia-1.2.0-DEV.pdf` through `julia-1.9.0-DEV.pdf` — historical development snapshots that should have been preserved. These DEV files were from when those were active development branches, not precursors to the same-version release.

The nightly PDF (`julia-1.14.0-DEV.pdf`) is simply overwritten each run — no cleanup needed.

**Note:** The deleted DEV PDFs and the stray `julia-1.14.0-DEV.commit` file on assets will need a one-time manual fix on the assets branch.

## Test plan
- [ ] CI passes
- [ ] No files deleted from assets on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)