### PR TITLE
Fix SystemError in julia-actions/cache post-cleanup

### DIFF
--- a/.github/actions/setup-pdf-build/action.yml
+++ b/.github/actions/setup-pdf-build/action.yml
@@ -33,7 +33,6 @@ runs:
       run: |
         sudo apt-get update
         sudo apt-get install -y python3-pygments fontconfig fonts-dejavu fonts-lato
-    - uses: julia-actions/cache@v3
     - name: Clone repositories
       shell: bash
       run: |

--- a/.github/workflows/PDFs.yml
+++ b/.github/workflows/PDFs.yml
@@ -94,6 +94,7 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: 1
+      - uses: julia-actions/cache@v3
       - run: |
           mkdir -p $BUILDROOT/tmp
           git clone https://github.com/JuliaLang/docs.julialang.org.git -b assets --single-branch $JULIA_DOCS

--- a/.github/workflows/PDFs.yml
+++ b/.github/workflows/PDFs.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: ./.github/actions/setup-pdf-build
         with:
           clone-assets: 'true'
+      - uses: julia-actions/cache@v3
       - id: versions
         run: |
           versions=$(julia --color=yes -e '
@@ -65,6 +66,7 @@ jobs:
       - uses: ./.github/actions/setup-pdf-build
         with:
           julia-ref: ${{ matrix.version != 'nightly' && format('v{0}', matrix.version) || '' }}
+      - uses: julia-actions/cache@v3
       - run: julia --color=yes pdf/make.jl build ${{ matrix.version }}
         env:
           DOCUMENTER_LATEX_DEBUG: ${{ github.workspace }}/latex-debug-logs


### PR DESCRIPTION
## Summary
- Move `julia-actions/cache@v3` from the composite action (`.github/actions/setup-pdf-build/`) into the workflow jobs directly
- Fixes `SystemError: opening file ".github/actions/setup-pdf-build/handle_caches.jl": No such file or directory` seen in [CI](https://github.com/JuliaLang/docs.julialang.org/actions/runs/23221018834/job/67493433211)
- The cache action's post-cleanup resolves `handle_caches.jl` relative to the composite action's directory instead of its own when used inside a composite action

## Test plan
- [ ] CI passes without the SystemError in post-job cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)