### PR TITLE
Reduce PDF commit size by preserving base commit

### DIFF
--- a/.github/actions/setup-pdf-build/action.yml
+++ b/.github/actions/setup-pdf-build/action.yml
@@ -17,7 +17,6 @@ runs:
         show-versioninfo: true
     - uses: zauguin/install-texlive@v4
       with:
-        version: latest
         packages: |
           scheme-basic
           collection-luatex

--- a/.github/workflows/PDFs.yml
+++ b/.github/workflows/PDFs.yml
@@ -29,7 +29,6 @@ jobs:
       - uses: ./.github/actions/setup-pdf-build
         with:
           clone-assets: 'true'
-      - uses: julia-actions/cache@v3
       - id: versions
         run: |
           versions=$(julia --color=yes -e '
@@ -66,7 +65,6 @@ jobs:
       - uses: ./.github/actions/setup-pdf-build
         with:
           julia-ref: ${{ matrix.version != 'nightly' && format('v{0}', matrix.version) || '' }}
-      - uses: julia-actions/cache@v3
       - run: julia --color=yes pdf/make.jl build ${{ matrix.version }}
         env:
           DOCUMENTER_LATEX_DEBUG: ${{ github.workspace }}/latex-debug-logs
@@ -94,7 +92,6 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: 1
-      - uses: julia-actions/cache@v3
       - run: |
           mkdir -p $BUILDROOT/tmp
           git clone https://github.com/JuliaLang/docs.julialang.org.git -b assets --single-branch $JULIA_DOCS

--- a/pdf/make.jl
+++ b/pdf/make.jl
@@ -259,7 +259,15 @@ function commit()
         if success(`git diff --cached --quiet`)
             @info "No changes to commit."
         else
-            run(`git commit --amend --date=now -m "PDF versions of Julia's manual."`)
+            # If only one commit exists (the base), create a new commit on top;
+            # otherwise amend the tip so the base commit stays stable and
+            # force-pushes only rewrite the small delta commit.
+            ncommits = parse(Int, readchomp(`git rev-list --count HEAD`))
+            if ncommits <= 1
+                run(`git commit -m "PDF updates"`)
+            else
+                run(`git commit --amend --date=now -m "PDF updates"`)
+            end
             run(`git push -f origin assets`)
         end
     end end


### PR DESCRIPTION
## Summary
- Instead of always amending the single commit on the `assets` branch (which rewrites the entire tree and re-uploads all PDFs), keep the base commit stable and only amend a second "delta" commit on top.
- On the first run after this change, a new commit is created. Subsequent runs amend only that tip commit, so force-pushes transfer only the changed objects.

## Test plan
- [ ] Verify first CI run after merge creates a second commit on `assets` (check `git rev-list --count` = 2)
- [ ] Verify subsequent runs amend only the tip commit while the base stays unchanged
- [ ] Confirm push size is reduced for runs that only update nightly

🤖 Generated with [Claude Code](https://claude.com/claude-code)